### PR TITLE
Update wordpress docker-compose examples to use the latest docker images

### DIFF
--- a/docker-compose/wordpress/docker-compose.dev.dist.yml
+++ b/docker-compose/wordpress/docker-compose.dev.dist.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   civicrm:
-    image: michaelmcandrew/civicrm-wordpress
+    image: michaelmcandrew/civicrm:wordpress
     hostname: civicrm
     environment:
       - PROJECT_NAME

--- a/docker-compose/wordpress/docker-compose.prod.dist.yml
+++ b/docker-compose/wordpress/docker-compose.prod.dist.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   civicrm:
-    image: michaelmcandrew/civicrm-wordpress
+    image: michaelmcandrew/civicrm:wordpress
     hostname: civicrm
     environment:
       - PROJECT_NAME


### PR DESCRIPTION
This updates the WordPress docker-compose examples to use tagged images, as discussed at CiviCRM Sprint 2022. 